### PR TITLE
feat(compressor): Add routine compressor #14

### DIFF
--- a/sleepops/e2e/sleepops.spec.ts
+++ b/sleepops/e2e/sleepops.spec.ts
@@ -69,7 +69,9 @@ test("shows the updated default morning routine step labels and durations", asyn
   await expect(page.getByLabel("Minutes wc")).toHaveValue("15");
   await expect(page.getByLabel("Minutes toilet")).toHaveValue("20");
   await expect(page.getByText("Day total")).toBeVisible();
-  await expect(page.getByText("1h 50m")).toBeVisible();
+  await expect(page.getByText("Day total").locator("..")).toContainText(
+    "1h 50m",
+  );
 });
 
 test("does not add default minutes for custom steps before they are recorded", async ({
@@ -82,7 +84,59 @@ test("does not add default minutes for custom steps before they are recorded", a
 
   await expect(page.locator('input[type="text"][value="Coffee"]')).toBeVisible();
   await expect(page.locator('input[aria-label^="Minutes "]').last()).toHaveValue("0");
-  await expect(page.getByText("1h 50m")).toBeVisible();
+  await expect(page.getByText("Day total").locator("..")).toContainText(
+    "1h 50m",
+  );
+});
+
+test("compresses classified routine tasks and applies the minimum morning", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByLabel("Minutes wake").fill("10");
+  await page.getByLabel("Minutes wc").fill("5");
+  await page.getByLabel("Minutes exercise").fill("20");
+  await page.getByLabel("Minutes shower").fill("15");
+  await page.getByLabel("Minutes eat").fill("10");
+  await page.getByLabel("Minutes brush-teeth").fill("5");
+  await page.getByLabel("Minutes toilet").fill("30");
+
+  await page.getByLabel("Classify exercise").selectOption("movable-evening");
+  await page.getByLabel("Classify shower").selectOption("movable-evening");
+  await page.getByLabel("Classify eat").selectOption("decision-setup");
+
+  const compressor = page.getByRole("region", { name: "Routine compressor" });
+
+  await expect(
+    compressor.getByRole("list", { name: "Minimum viable morning tasks" }),
+  ).toContainText("Wake (boot up)");
+  await expect(
+    compressor.getByRole("list", { name: "Moved evening tasks" }),
+  ).toContainText("Ex(ercise)");
+  await expect(
+    compressor.getByRole("list", { name: "Moved evening tasks" }),
+  ).toContainText("Shower");
+  await expect(
+    compressor.getByRole("list", { name: "Evening preparation tasks" }),
+  ).toContainText("Eat");
+  await expect(compressor).toContainText("Compressed morning duration");
+  await expect(compressor).toContainText("50m");
+
+  await page
+    .getByRole("button", {
+      name: "Apply compressed duration to sleep contract",
+    })
+    .click();
+
+  await expect(
+    page.getByRole("spinbutton", { name: "Morning routine duration" }),
+  ).toHaveValue("50");
+  await expect(page.getByText("Start shutdown by 21:55")).toBeVisible();
+  await expect(page.getByRole("definition").filter({ hasText: "07:40" }))
+    .toBeVisible();
+  await expect(page.getByRole("definition").filter({ hasText: "22:40" }))
+    .toBeVisible();
 });
 
 test("includes displayed fallback minutes in the day total for older stored days", async ({
@@ -118,7 +172,9 @@ test("includes displayed fallback minutes in the day total for older stored days
   await expect(page.getByLabel("Minutes wake")).toHaveValue("20");
   await expect(page.getByLabel("Minutes wc")).toHaveValue("15");
   await expect(page.getByLabel("Minutes toilet")).toHaveValue("20");
-  await expect(page.getByText("1h 55m")).toBeVisible();
+  await expect(page.getByText("Day total").locator("..")).toContainText(
+    "1h 55m",
+  );
 });
 
 test("records step durations, persists them, and feeds the measured total into the sleep contract", async ({

--- a/sleepops/src/app/sleep-compiler.tsx
+++ b/sleepops/src/app/sleep-compiler.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/sleep";
 import {
   addStep,
+  compressMorningRoutine,
   createDefaultMorningRoutineProfiler,
   defaultStepMinutes,
   measuredMorningRoutineMinutes,
@@ -15,11 +16,15 @@ import {
   pruneToLastNDays,
   removeStep,
   serializeProfiler,
+  setStepClassification,
   setStepLabel,
   setStepMinutesForDay,
   toDateKey,
   topTimeLeaks,
+  type CompressedRoutineTask,
   type MorningRoutineProfiler,
+  type RoutineCompression,
+  type RoutineStepClassification,
 } from "@/lib/routine";
 
 const MINUTES_STEP = 5;
@@ -28,6 +33,14 @@ const MAX_BUFFER_MINUTES = 240;
 const PROFILER_RETENTION_DAYS = 7;
 const PROFILER_STORAGE_KEY = "sleepops.morningRoutineProfiler.v1";
 const PROFILER_CHANGE_EVENT = "sleepops.morningRoutineProfiler.change";
+const STEP_CLASSIFICATION_OPTIONS: Array<{
+  value: RoutineStepClassification;
+  label: string;
+}> = [
+  { value: "required-morning", label: "Required morning" },
+  { value: "movable-evening", label: "Move to evening" },
+  { value: "decision-setup", label: "Decision/setup" },
+];
 
 let profilerMemorySnapshot: string | null = null;
 
@@ -100,6 +113,10 @@ export function SleepCompiler() {
       : manualMorningRoutineMinutes;
   const recordDayMinutesByStepId =
     profiler.days.find((day) => day.date === recordDateKey)?.minutesByStepId;
+  const routineCompression: RoutineCompression = useMemo(
+    () => compressMorningRoutine(profiler, recordDayMinutesByStepId),
+    [profiler, recordDayMinutesByStepId],
+  );
 
   const schedule = useMemo(
     () =>
@@ -112,6 +129,10 @@ export function SleepCompiler() {
   );
 
   const hasWarning = schedule.constraintWarning !== null;
+  const applyCompressedRoutine = () => {
+    setManualMorningRoutineMinutes(routineCompression.minimumMorningMinutes);
+    setUseProfiledMorningRoutine(false);
+  };
 
   const results = [
     { label: "Wake time", value: schedule.wakeTime },
@@ -278,7 +299,7 @@ export function SleepCompiler() {
 
                     return (
                       <div
-                        className="grid grid-cols-[1fr_120px_auto] items-center gap-2"
+                        className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_160px_120px_auto] sm:items-center"
                         key={step.id}
                       >
                         <input
@@ -293,6 +314,27 @@ export function SleepCompiler() {
                           type="text"
                           value={step.label}
                         />
+                        <select
+                          aria-label={`Classify ${step.id}`}
+                          className="h-12 w-full border border-[#cfd8d1] bg-[#fbfcfb] px-3 text-sm font-semibold text-[#18181b] outline-none focus:border-[#166534]"
+                          onChange={(event) =>
+                            updateMorningProfiler((current) =>
+                              setStepClassification(
+                                current,
+                                step.id,
+                                event.currentTarget
+                                  .value as RoutineStepClassification,
+                              ),
+                            )
+                          }
+                          value={step.classification}
+                        >
+                          {STEP_CLASSIFICATION_OPTIONS.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
                         <input
                           aria-label={`Minutes ${step.id}`}
                           className="h-12 w-full border border-[#cfd8d1] bg-[#fbfcfb] px-3 text-lg font-semibold text-[#18181b] outline-none focus:border-[#166534]"
@@ -393,6 +435,71 @@ export function SleepCompiler() {
             </div>
           </section>
 
+          <section
+            aria-labelledby="routine-compressor-heading"
+            className="border border-[#d8dfda] bg-white p-5 shadow-sm sm:p-6"
+          >
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h2
+                  className="text-xl font-semibold"
+                  id="routine-compressor-heading"
+                >
+                  Routine compressor
+                </h2>
+                <p className="mt-1 text-sm text-[#52525b]">
+                  Uses the selected profiler day.
+                </p>
+              </div>
+              <div className="text-sm text-[#52525b]">
+                Profiled total{" "}
+                <strong className="text-[#18181b]">
+                  {formatDuration(routineCompression.totalProfiledMinutes)}
+                </strong>
+              </div>
+            </div>
+
+            <div className="mt-5 grid gap-3 lg:grid-cols-3">
+              <CompressionBlock
+                emptyText="No required morning tasks with minutes."
+                listLabel="Minimum viable morning tasks"
+                minutes={routineCompression.minimumMorningMinutes}
+                tasks={routineCompression.minimumMorningTasks}
+                title="Minimum viable morning"
+              />
+              <CompressionBlock
+                emptyText="No tasks marked movable yet."
+                listLabel="Moved evening tasks"
+                minutes={routineCompression.eveningMinutes}
+                tasks={routineCompression.eveningTasks}
+                title="Moved to evening"
+              />
+              <CompressionBlock
+                emptyText="No decision/setup tasks marked yet."
+                listLabel="Evening preparation tasks"
+                minutes={routineCompression.eveningPreparationMinutes}
+                tasks={routineCompression.eveningPreparationTasks}
+                title="Evening preparation block"
+              />
+            </div>
+
+            <div className="mt-5 flex flex-col gap-3 border-t border-[#e4e7e4] pt-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-sm text-[#52525b]">
+                Compressed morning duration
+                <strong className="ml-2 text-lg text-[#18181b]">
+                  {formatDuration(routineCompression.minimumMorningMinutes)}
+                </strong>
+              </div>
+              <button
+                className="h-12 border border-[#166534] bg-[#166534] px-4 text-sm font-semibold text-white hover:bg-[#14532d]"
+                onClick={applyCompressedRoutine}
+                type="button"
+              >
+                Apply compressed duration to sleep contract
+              </button>
+            </div>
+          </section>
+
           <dl className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
             {results.map((result) => (
               <div
@@ -451,6 +558,48 @@ type DurationControlProps = {
   onChange: (value: number) => void;
   disabled?: boolean;
 };
+
+function CompressionBlock({
+  emptyText,
+  listLabel,
+  minutes,
+  tasks,
+  title,
+}: {
+  emptyText: string;
+  listLabel: string;
+  minutes: number;
+  tasks: CompressedRoutineTask[];
+  title: string;
+}) {
+  return (
+    <div className="min-h-40 border border-[#d8dfda] bg-[#fbfcfb] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold text-[#18181b]">{title}</h3>
+        <strong className="shrink-0 text-sm text-[#18181b]">
+          {formatDuration(minutes)}
+        </strong>
+      </div>
+      {tasks.length === 0 ? (
+        <p className="mt-4 text-sm text-[#52525b]">{emptyText}</p>
+      ) : (
+        <ol aria-label={listLabel} className="mt-4 grid gap-2 text-sm">
+          {tasks.map((task) => (
+            <li
+              className="flex items-center justify-between gap-3 text-[#3f3f46]"
+              key={task.stepId}
+            >
+              <span className="min-w-0 truncate">{task.label}</span>
+              <span className="shrink-0 font-semibold text-[#18181b]">
+                {formatDuration(task.minutes)}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
 
 function DurationControl({
   id,

--- a/sleepops/src/lib/routine/compressor.test.ts
+++ b/sleepops/src/lib/routine/compressor.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { compressMorningRoutine } from "./compressor";
+import type { MorningRoutineProfiler } from "./profiler";
+
+describe("routine compressor", () => {
+  it("keeps required tasks in the morning and moves eligible tasks to evening blocks", () => {
+    const compression = compressMorningRoutine(
+      createProfiler([
+        ["wake", "Wake", "required-morning"],
+        ["shower", "Shower", "movable-evening"],
+        ["clothes", "Choose clothes", "decision-setup"],
+        ["coffee", "Coffee", "required-morning"],
+      ]),
+      {
+        wake: 10,
+        shower: 20,
+        clothes: 5,
+        coffee: 0,
+      },
+    );
+
+    expect(compression.minimumMorningTasks.map((task) => task.stepId)).toEqual([
+      "wake",
+    ]);
+    expect(compression.eveningTasks.map((task) => task.stepId)).toEqual([
+      "shower",
+    ]);
+    expect(
+      compression.eveningPreparationTasks.map((task) => task.stepId),
+    ).toEqual(["clothes"]);
+    expect(compression.minimumMorningMinutes).toBe(10);
+    expect(compression.eveningMinutes).toBe(20);
+    expect(compression.eveningPreparationMinutes).toBe(5);
+    expect(compression.totalProfiledMinutes).toBe(35);
+  });
+
+  it("uses routine defaults for missing step minutes", () => {
+    const compression = compressMorningRoutine(
+      createProfiler([
+        ["wake", "Wake", "required-morning"],
+        ["toilet", "Commute/Post-morning", "movable-evening"],
+        ["custom", "Custom", "decision-setup"],
+      ]),
+    );
+
+    expect(compression.minimumMorningMinutes).toBe(15);
+    expect(compression.eveningMinutes).toBe(20);
+    expect(compression.eveningPreparationMinutes).toBe(0);
+  });
+
+  it("preserves original routine order inside each compressed block", () => {
+    const compression = compressMorningRoutine(
+      createProfiler([
+        ["bag", "Pack bag", "decision-setup"],
+        ["wake", "Wake", "required-morning"],
+        ["shower", "Shower", "movable-evening"],
+        ["meds", "Meds", "required-morning"],
+        ["clothes", "Choose clothes", "decision-setup"],
+        ["exercise", "Exercise", "movable-evening"],
+      ]),
+      {
+        exercise: 30,
+        clothes: 5,
+        meds: 2,
+        shower: 15,
+        wake: 8,
+        bag: 4,
+      },
+    );
+
+    expect(compression.minimumMorningTasks.map((task) => task.stepId)).toEqual([
+      "wake",
+      "meds",
+    ]);
+    expect(compression.eveningTasks.map((task) => task.stepId)).toEqual([
+      "shower",
+      "exercise",
+    ]);
+    expect(
+      compression.eveningPreparationTasks.map((task) => task.stepId),
+    ).toEqual(["bag", "clothes"]);
+  });
+});
+
+function createProfiler(
+  steps: Array<
+    [
+      id: string,
+      label: string,
+      classification: MorningRoutineProfiler["steps"][number]["classification"],
+    ]
+  >,
+): MorningRoutineProfiler {
+  return {
+    steps: steps.map(([id, label, classification]) => ({
+      id,
+      label,
+      classification,
+    })),
+    days: [],
+  };
+}

--- a/sleepops/src/lib/routine/compressor.ts
+++ b/sleepops/src/lib/routine/compressor.ts
@@ -1,0 +1,78 @@
+import {
+  clampWholeMinutes,
+  defaultStepMinutes,
+  normalizeStepClassification,
+  type MorningRoutineProfiler,
+  type RoutineStepClassification,
+} from "./profiler";
+
+export type CompressedRoutineTask = {
+  stepId: string;
+  label: string;
+  classification: RoutineStepClassification;
+  minutes: number;
+};
+
+export type RoutineCompression = {
+  minimumMorningTasks: CompressedRoutineTask[];
+  eveningTasks: CompressedRoutineTask[];
+  eveningPreparationTasks: CompressedRoutineTask[];
+  minimumMorningMinutes: number;
+  eveningMinutes: number;
+  eveningPreparationMinutes: number;
+  totalProfiledMinutes: number;
+};
+
+export function compressMorningRoutine(
+  profiler: MorningRoutineProfiler,
+  minutesByStepId?: Record<string, unknown>,
+): RoutineCompression {
+  const minimumMorningTasks: CompressedRoutineTask[] = [];
+  const eveningTasks: CompressedRoutineTask[] = [];
+  const eveningPreparationTasks: CompressedRoutineTask[] = [];
+
+  for (const step of profiler.steps) {
+    const minutes = clampWholeMinutes(
+      minutesByStepId?.[step.id] ?? defaultStepMinutes(step.id),
+    );
+
+    if (minutes === 0) {
+      continue;
+    }
+
+    const classification = normalizeStepClassification(step.classification);
+    const task = {
+      stepId: step.id,
+      label: step.label,
+      classification,
+      minutes,
+    };
+
+    if (classification === "movable-evening") {
+      eveningTasks.push(task);
+    } else if (classification === "decision-setup") {
+      eveningPreparationTasks.push(task);
+    } else {
+      minimumMorningTasks.push(task);
+    }
+  }
+
+  const minimumMorningMinutes = sumTaskMinutes(minimumMorningTasks);
+  const eveningMinutes = sumTaskMinutes(eveningTasks);
+  const eveningPreparationMinutes = sumTaskMinutes(eveningPreparationTasks);
+
+  return {
+    minimumMorningTasks,
+    eveningTasks,
+    eveningPreparationTasks,
+    minimumMorningMinutes,
+    eveningMinutes,
+    eveningPreparationMinutes,
+    totalProfiledMinutes:
+      minimumMorningMinutes + eveningMinutes + eveningPreparationMinutes,
+  };
+}
+
+function sumTaskMinutes(tasks: CompressedRoutineTask[]): number {
+  return tasks.reduce((sum, task) => sum + task.minutes, 0);
+}

--- a/sleepops/src/lib/routine/index.ts
+++ b/sleepops/src/lib/routine/index.ts
@@ -1,14 +1,18 @@
 export {
+  DEFAULT_ROUTINE_STEP_CLASSIFICATION,
+  ROUTINE_STEP_CLASSIFICATIONS,
   addStep,
   clampWholeMinutes,
   createDefaultMorningRoutineProfiler,
   defaultStepMinutes,
   isDateKey,
   measuredMorningRoutineMinutes,
+  normalizeStepClassification,
   parseProfiler,
   pruneToLastNDays,
   removeStep,
   serializeProfiler,
+  setStepClassification,
   setStepLabel,
   setStepMinutesForDay,
   toDateKey,
@@ -18,4 +22,10 @@ export {
   type RoutineDay,
   type RoutineLeak,
   type RoutineStep,
+  type RoutineStepClassification,
 } from "./profiler";
+export {
+  compressMorningRoutine,
+  type CompressedRoutineTask,
+  type RoutineCompression,
+} from "./compressor";

--- a/sleepops/src/lib/routine/profiler.test.ts
+++ b/sleepops/src/lib/routine/profiler.test.ts
@@ -11,6 +11,7 @@ import {
   setStepMinutesForDay,
   topTimeLeaks,
   totalMinutesForDay,
+  type MorningRoutineProfiler,
 } from "./profiler";
 
 const DEFAULT_STEP_IDS = [
@@ -25,7 +26,9 @@ const DEFAULT_STEP_IDS = [
 
 describe("morning routine profiler", () => {
   it("uses the requested default step titles in chronological order", () => {
-    expect(createDefaultMorningRoutineProfiler().steps).toEqual([
+    const steps = createDefaultMorningRoutineProfiler().steps;
+
+    expect(steps.map(({ id, label }) => ({ id, label }))).toEqual([
       { id: "wake", label: "Wake (boot up)" },
       { id: "wc", label: "WC" },
       { id: "exercise", label: "Ex(ercise)" },
@@ -34,6 +37,9 @@ describe("morning routine profiler", () => {
       { id: "brush-teeth", label: "Brush Teeth" },
       { id: "toilet", label: "Commute/Post-morning" },
     ]);
+    expect(new Set(steps.map((step) => step.classification))).toEqual(
+      new Set(["required-morning"]),
+    );
   });
 
   it("uses 15-minute defaults for built-in steps except the final 20-minute commute step", () => {
@@ -250,6 +256,19 @@ describe("morning routine profiler", () => {
     expect(parseProfiler(serializeProfiler(profiler))).toEqual(profiler);
   });
 
+  it("defaults older persisted steps to required morning classification", () => {
+    const parsed = parseProfiler(
+      JSON.stringify({
+        steps: [{ id: "wake", label: "Wake" }],
+        days: [],
+      }),
+    );
+
+    expect(parsed?.steps).toEqual([
+      { id: "wake", label: "Wake", classification: "required-morning" },
+    ]);
+  });
+
   it("preserves an intentionally empty step list in persisted data", () => {
     const parsed = parseProfiler(JSON.stringify({ steps: [], days: [] }));
 
@@ -265,7 +284,13 @@ describe("morning routine profiler", () => {
   it("sanitizes persisted day minutes and ignores malformed rows", () => {
     const parsed = parseProfiler(
       JSON.stringify({
-        steps: [{ id: "wake", label: "Wake" }],
+        steps: [
+          {
+            id: "wake",
+            label: "Wake",
+            classification: "movable-evening",
+          },
+        ],
         days: [
           {
             date: "2026-05-05",
@@ -276,7 +301,9 @@ describe("morning routine profiler", () => {
       }),
     );
 
-    expect(parsed?.steps).toEqual([{ id: "wake", label: "Wake" }]);
+    expect(parsed?.steps).toEqual([
+      { id: "wake", label: "Wake", classification: "movable-evening" },
+    ]);
     expect(parsed?.days[0]?.date).toBe("2026-05-05");
     expect(Object.getPrototypeOf(parsed?.days[0]?.minutesByStepId)).toBeNull();
     expect(
@@ -311,10 +338,18 @@ describe("morning routine profiler", () => {
   });
 
   it("does not seed dangerous step ids when creating a new day", () => {
-    const profiler = {
+    const profiler: MorningRoutineProfiler = {
       steps: [
-        { id: "wake", label: "Wake (boot up)" },
-        { id: "__proto__", label: "Exploit" },
+        {
+          id: "wake",
+          label: "Wake (boot up)",
+          classification: "required-morning",
+        },
+        {
+          id: "__proto__",
+          label: "Exploit",
+          classification: "required-morning",
+        },
       ],
       days: [],
     };

--- a/sleepops/src/lib/routine/profiler.ts
+++ b/sleepops/src/lib/routine/profiler.ts
@@ -23,6 +23,12 @@ export type MorningRoutineProfiler = {
   days: RoutineDay[];
 };
 
+type StoredRoutineStep = {
+  id: string;
+  label: string;
+  classification?: unknown;
+};
+
 export type RoutineLeak = {
   stepId: string;
   label: string;
@@ -349,23 +355,17 @@ export function parseProfiler(json: string): MorningRoutineProfiler | null {
     if (!parsed || typeof parsed !== "object") {
       return null;
     }
-    const candidate = parsed as Partial<MorningRoutineProfiler>;
+    const candidate = parsed as { steps?: unknown; days?: unknown };
     if (!Array.isArray(candidate.steps) || !Array.isArray(candidate.days)) {
       return null;
     }
 
     const steps = candidate.steps
-      .filter((step): step is RoutineStep =>
-        Boolean(step) &&
-        typeof (step as RoutineStep).id === "string" &&
-        typeof (step as RoutineStep).label === "string",
-      )
+      .filter((step): step is StoredRoutineStep => isStoredRoutineStep(step))
       .map((step) => ({
         id: step.id,
         label: step.label,
-        classification: normalizeStepClassification(
-          (step as Partial<RoutineStep>).classification,
-        ),
+        classification: normalizeStepClassification(step.classification),
       }));
 
     const days = candidate.days
@@ -399,6 +399,15 @@ function isRoutineStepClassification(
 ): value is RoutineStepClassification {
   return ROUTINE_STEP_CLASSIFICATIONS.some(
     (classification) => classification === value,
+  );
+}
+
+function isStoredRoutineStep(value: unknown): value is StoredRoutineStep {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    typeof (value as StoredRoutineStep).id === "string" &&
+    typeof (value as StoredRoutineStep).label === "string"
   );
 }
 

--- a/sleepops/src/lib/routine/profiler.ts
+++ b/sleepops/src/lib/routine/profiler.ts
@@ -1,6 +1,16 @@
+export const ROUTINE_STEP_CLASSIFICATIONS = [
+  "required-morning",
+  "movable-evening",
+  "decision-setup",
+] as const;
+
+export type RoutineStepClassification =
+  (typeof ROUTINE_STEP_CLASSIFICATIONS)[number];
+
 export type RoutineStep = {
   id: string;
   label: string;
+  classification: RoutineStepClassification;
 };
 
 export type RoutineDay = {
@@ -21,14 +31,44 @@ export type RoutineLeak = {
 
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const DEFAULT_STEP_MINUTES = 15;
+export const DEFAULT_ROUTINE_STEP_CLASSIFICATION: RoutineStepClassification =
+  "required-morning";
 const DEFAULT_PROFILER_STEPS: RoutineStep[] = [
-  { id: "wake", label: "Wake (boot up)" },
-  { id: "wc", label: "WC" },
-  { id: "exercise", label: "Ex(ercise)" },
-  { id: "shower", label: "Shower" },
-  { id: "eat", label: "Eat" },
-  { id: "brush-teeth", label: "Brush Teeth" },
-  { id: "toilet", label: "Commute/Post-morning" },
+  {
+    id: "wake",
+    label: "Wake (boot up)",
+    classification: DEFAULT_ROUTINE_STEP_CLASSIFICATION,
+  },
+  {
+    id: "wc",
+    label: "WC",
+    classification: DEFAULT_ROUTINE_STEP_CLASSIFICATION,
+  },
+  {
+    id: "exercise",
+    label: "Ex(ercise)",
+    classification: DEFAULT_ROUTINE_STEP_CLASSIFICATION,
+  },
+  {
+    id: "shower",
+    label: "Shower",
+    classification: DEFAULT_ROUTINE_STEP_CLASSIFICATION,
+  },
+  {
+    id: "eat",
+    label: "Eat",
+    classification: DEFAULT_ROUTINE_STEP_CLASSIFICATION,
+  },
+  {
+    id: "brush-teeth",
+    label: "Brush Teeth",
+    classification: DEFAULT_ROUTINE_STEP_CLASSIFICATION,
+  },
+  {
+    id: "toilet",
+    label: "Commute/Post-morning",
+    classification: DEFAULT_ROUTINE_STEP_CLASSIFICATION,
+  },
 ];
 const BUILT_IN_STEP_IDS = new Set(DEFAULT_PROFILER_STEPS.map((step) => step.id));
 const POST_MORNING_STEP_ID = "toilet";
@@ -126,9 +166,23 @@ export function setStepLabel(
   };
 }
 
+export function setStepClassification(
+  profiler: MorningRoutineProfiler,
+  stepId: string,
+  classification: RoutineStepClassification,
+): MorningRoutineProfiler {
+  return {
+    ...profiler,
+    steps: profiler.steps.map((step) =>
+      step.id === stepId ? { ...step, classification } : step,
+    ),
+  };
+}
+
 export function addStep(
   profiler: MorningRoutineProfiler,
-  step: RoutineStep,
+  step: Omit<RoutineStep, "classification"> &
+    Partial<Pick<RoutineStep, "classification">>,
 ): MorningRoutineProfiler {
   if (!step.id.trim()) {
     throw new RangeError("Step id must be non-empty.");
@@ -138,7 +192,17 @@ export function addStep(
     throw new RangeError(`Step id already exists: ${step.id}`);
   }
 
-  return { ...profiler, steps: [...profiler.steps, step] };
+  return {
+    ...profiler,
+    steps: [
+      ...profiler.steps,
+      {
+        ...step,
+        classification:
+          step.classification ?? DEFAULT_ROUTINE_STEP_CLASSIFICATION,
+      },
+    ],
+  };
 }
 
 export function removeStep(
@@ -296,7 +360,13 @@ export function parseProfiler(json: string): MorningRoutineProfiler | null {
         typeof (step as RoutineStep).id === "string" &&
         typeof (step as RoutineStep).label === "string",
       )
-      .map((step) => ({ id: step.id, label: step.label }));
+      .map((step) => ({
+        id: step.id,
+        label: step.label,
+        classification: normalizeStepClassification(
+          (step as Partial<RoutineStep>).classification,
+        ),
+      }));
 
     const days = candidate.days
       .filter((day): day is RoutineDay =>
@@ -314,6 +384,22 @@ export function parseProfiler(json: string): MorningRoutineProfiler | null {
   } catch {
     return null;
   }
+}
+
+export function normalizeStepClassification(
+  value: unknown,
+): RoutineStepClassification {
+  return isRoutineStepClassification(value)
+    ? value
+    : DEFAULT_ROUTINE_STEP_CLASSIFICATION;
+}
+
+function isRoutineStepClassification(
+  value: unknown,
+): value is RoutineStepClassification {
+  return ROUTINE_STEP_CLASSIFICATIONS.some(
+    (classification) => classification === value,
+  );
 }
 
 function sanitizeMinutesByStepId(


### PR DESCRIPTION
## Summary
- Extends the existing morning routine step model with required morning, movable evening, and decision/setup classifications while preserving older local data.
- Adds deterministic routine compression that keeps required tasks in the morning, moves eligible tasks to evening, and batches setup decisions into an evening preparation block.
- Updates the SleepOps UI so users can classify profiled tasks, inspect the compressed plan, and apply the minimum viable morning duration to the sleep contract.

Closes #14.

## Validation
- `npm run lint`
- `npm test`
- `npm run build`
- `npm --prefix sleepops run test:e2e`