### PR TITLE
fix(profiler): Narrow stored step parsing #27

### DIFF
--- a/sleepops/src/lib/routine/profiler.test.ts
+++ b/sleepops/src/lib/routine/profiler.test.ts
@@ -269,6 +269,33 @@ describe("morning routine profiler", () => {
     ]);
   });
 
+  it("normalizes only narrowed string persisted step classifications", () => {
+    const parsed = parseProfiler(
+      JSON.stringify({
+        steps: [
+          { id: "wake", label: "Wake", classification: "movable-evening" },
+          { id: "shower", label: "Shower", classification: "invalid" },
+          { id: "eat", label: "Eat", classification: 7 },
+          {
+            id: "bag",
+            label: "Pack bag",
+            classification: { value: "decision-setup" },
+          },
+          { id: 7, label: "Bad id", classification: "decision-setup" },
+          { id: "bad-label", label: null, classification: "decision-setup" },
+        ],
+        days: [],
+      }),
+    );
+
+    expect(parsed?.steps).toEqual([
+      { id: "wake", label: "Wake", classification: "movable-evening" },
+      { id: "shower", label: "Shower", classification: "required-morning" },
+      { id: "eat", label: "Eat", classification: "required-morning" },
+      { id: "bag", label: "Pack bag", classification: "required-morning" },
+    ]);
+  });
+
   it("preserves an intentionally empty step list in persisted data", () => {
     const parsed = parseProfiler(JSON.stringify({ steps: [], days: [] }));
 

--- a/sleepops/src/lib/routine/profiler.ts
+++ b/sleepops/src/lib/routine/profiler.ts
@@ -26,7 +26,7 @@ export type MorningRoutineProfiler = {
 type StoredRoutineStep = {
   id: string;
   label: string;
-  classification?: unknown;
+  classification?: string;
 };
 
 export type RoutineLeak = {
@@ -361,7 +361,8 @@ export function parseProfiler(json: string): MorningRoutineProfiler | null {
     }
 
     const steps = candidate.steps
-      .filter((step): step is StoredRoutineStep => isStoredRoutineStep(step))
+      .map(parseStoredRoutineStep)
+      .filter((step): step is StoredRoutineStep => step !== null)
       .map((step) => ({
         id: step.id,
         label: step.label,
@@ -402,13 +403,29 @@ function isRoutineStepClassification(
   );
 }
 
-function isStoredRoutineStep(value: unknown): value is StoredRoutineStep {
-  return (
-    Boolean(value) &&
-    typeof value === "object" &&
-    typeof (value as StoredRoutineStep).id === "string" &&
-    typeof (value as StoredRoutineStep).label === "string"
-  );
+function parseStoredRoutineStep(value: unknown): StoredRoutineStep | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const candidate = value as {
+    id?: unknown;
+    label?: unknown;
+    classification?: unknown;
+  };
+
+  if (typeof candidate.id !== "string" || typeof candidate.label !== "string") {
+    return null;
+  }
+
+  return {
+    id: candidate.id,
+    label: candidate.label,
+    classification:
+      typeof candidate.classification === "string"
+        ? candidate.classification
+        : undefined,
+  };
 }
 
 function sanitizeMinutesByStepId(


### PR DESCRIPTION
## Summary
- Narrow persisted profiler step parsing so only string classifications are passed into normalization.
- Preserve the legacy fallback to required morning for missing, invalid, or non-string persisted classifications.
- Add regression coverage for valid, invalid, and malformed persisted step classification data.

## Validation
- `npm run lint`
- `npm test`
- `npm run build`
- `npm --prefix sleepops run test:e2e`

Closes #27.