### PR TITLE
feat(shutdown): Add evening shutdown assistant #15

### DIFF
--- a/sleepops/e2e/sleepops.spec.ts
+++ b/sleepops/e2e/sleepops.spec.ts
@@ -198,11 +198,35 @@ test("compresses classified routine tasks and applies the minimum morning", asyn
   await expect(
     page.getByRole("spinbutton", { name: "Morning routine duration" }),
   ).toHaveValue("50");
-  await expect(page.getByText("Start shutdown by 21:55")).toBeVisible();
+  await expect(page.getByText("Start shutdown by 21:25")).toBeVisible();
   await expect(page.getByRole("definition").filter({ hasText: "07:40" }))
     .toBeVisible();
   await expect(page.getByRole("definition").filter({ hasText: "22:40" }))
     .toBeVisible();
+});
+
+test("keeps moved tasks outside shutdown mode when they do not fit", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByLabel("Minutes exercise").fill("60");
+  await page.getByLabel("Classify exercise").selectOption("movable-evening");
+
+  await expect(page.getByText("Shutdown duration").locator("..")).toContainText(
+    "45m",
+  );
+
+  await page.getByRole("button", { name: "Preview shutdown mode" }).click();
+
+  const assistant = page.getByRole("region", {
+    name: "Evening shutdown assistant",
+  });
+
+  await assistant.getByRole("button", { name: "Done" }).click();
+
+  await expect(assistant).not.toContainText("Do evening task: Ex(ercise)");
+  await expect(assistant).toContainText("Dental Care.");
 });
 
 test("previews shutdown mode and advances one physical action at a time", async ({
@@ -352,6 +376,9 @@ test("keeps an intentionally empty routine step list across reloads", async ({
   page,
 }) => {
   await page.goto("/");
+  await expect(
+    page.getByRole("heading", { name: "Tonight's shutdown deadline" }),
+  ).toBeVisible();
 
   while (await page.getByRole("button", { name: /Remove step/ }).count()) {
     await page.getByRole("button", { name: /Remove step/ }).first().click();
@@ -360,6 +387,9 @@ test("keeps an intentionally empty routine step list across reloads", async ({
   await expect(page.getByRole("button", { name: /Remove step/ })).toHaveCount(0);
 
   await page.reload();
+  await expect(
+    page.getByRole("heading", { name: "Tonight's shutdown deadline" }),
+  ).toBeVisible();
 
   await expect(page.getByRole("button", { name: /Remove step/ })).toHaveCount(0);
 });

--- a/sleepops/e2e/sleepops.spec.ts
+++ b/sleepops/e2e/sleepops.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "playwright/test";
 
 test.beforeEach(async ({ page }) => {
-  await page.clock.setFixedTime(new Date("2026-05-10T12:00:00"));
+  await page.clock.setFixedTime(new Date("2026-05-10T12:00:00Z"));
 });
 
 test("compiles the default 9-5 sleep contract", async ({ page }) => {

--- a/sleepops/e2e/sleepops.spec.ts
+++ b/sleepops/e2e/sleepops.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "playwright/test";
 
+test.beforeEach(async ({ page }) => {
+  await page.clock.setFixedTime(new Date("2026-05-10T12:00:00"));
+});
+
 test("compiles the default 9-5 sleep contract", async ({ page }) => {
   await page.goto("/");
 
@@ -154,6 +158,55 @@ test("compresses classified routine tasks and applies the minimum morning", asyn
     .toBeVisible();
   await expect(page.getByRole("definition").filter({ hasText: "22:40" }))
     .toBeVisible();
+});
+
+test("previews shutdown mode and advances one physical action at a time", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByLabel("Classify shower").selectOption("movable-evening");
+  await page.getByLabel("Classify eat").selectOption("decision-setup");
+
+  await page.getByRole("button", { name: "Preview shutdown mode" }).click();
+
+  const assistant = page.getByRole("region", {
+    name: "Evening shutdown assistant",
+  });
+
+  await expect(assistant).toBeVisible();
+  await expect(assistant).toContainText("Close laptop and put it away.");
+  await expect(assistant).not.toContainText("Do evening task: Shower");
+  await expect(
+    page.getByRole("spinbutton", { name: "Morning routine duration" }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("heading", { name: "Routine compressor" }),
+  ).toHaveCount(0);
+
+  await assistant.getByRole("button", { name: "Done" }).click();
+
+  await expect(assistant).toContainText("Do evening task: Shower");
+  await expect(assistant).not.toContainText("Close laptop and put it away.");
+
+  await assistant.getByRole("button", { name: "Done" }).click();
+  await expect(assistant).toContainText("Prep for morning: Eat");
+
+  await assistant.getByRole("button", { name: "Done" }).click();
+  await expect(assistant).toContainText("Brush teeth.");
+
+  await assistant.getByRole("button", { name: "Done" }).click();
+  await expect(assistant).toContainText("Get in bed and turn lights out.");
+
+  await assistant.getByRole("button", { name: "Done" }).click();
+  await expect(assistant).toContainText("Lights out");
+  await expect(assistant).toContainText("Shutdown complete. Go to bed now.");
+
+  await assistant.getByRole("button", { name: "Back to planning" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Tonight's shutdown deadline" }),
+  ).toBeVisible();
 });
 
 test("includes displayed fallback minutes in the day total for older stored days", async ({

--- a/sleepops/e2e/sleepops.spec.ts
+++ b/sleepops/e2e/sleepops.spec.ts
@@ -51,6 +51,34 @@ test("recalculates for a 10-6 day and warns on impossible input", async ({
   ).toBeVisible();
 });
 
+test("shows active shutdown mode during the shutdown window even when overbooked", async ({
+  page,
+}) => {
+  await page.clock.setFixedTime(new Date("2026-05-10T09:30:00Z"));
+  await page.goto("/");
+
+  await page.getByLabel("Work start time").fill("10:00");
+  await page
+    .getByRole("spinbutton", { name: "Morning routine duration" })
+    .fill("840");
+  await page
+    .getByRole("spinbutton", { name: "Commute / buffer duration" })
+    .fill("60");
+
+  const assistant = page.getByRole("region", {
+    name: "Evening shutdown assistant",
+  });
+
+  await expect(assistant).toBeVisible();
+  await expect(assistant).toContainText("Close laptop and put it away.");
+  await expect(
+    page.getByRole("spinbutton", { name: "Morning routine duration" }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("heading", { name: "Routine compressor" }),
+  ).toHaveCount(0);
+});
+
 test("normalizes typed duration values to the allowed range and step", async ({
   page,
 }) => {

--- a/sleepops/e2e/sleepops.spec.ts
+++ b/sleepops/e2e/sleepops.spec.ts
@@ -79,6 +79,23 @@ test("shows active shutdown mode during the shutdown window even when overbooked
   ).toHaveCount(0);
 });
 
+test("loads directly into active shutdown mode during the default shutdown window", async ({
+  page,
+}) => {
+  await page.clock.setFixedTime(new Date("2026-05-10T21:30:00Z"));
+  await page.goto("/");
+
+  const assistant = page.getByRole("region", {
+    name: "Evening shutdown assistant",
+  });
+
+  await expect(assistant).toBeVisible();
+  await expect(assistant).toContainText("Close laptop and put it away.");
+  await expect(
+    page.getByRole("spinbutton", { name: "Morning routine duration" }),
+  ).toHaveCount(0);
+});
+
 test("normalizes typed duration values to the allowed range and step", async ({
   page,
 }) => {
@@ -221,7 +238,7 @@ test("previews shutdown mode and advances one physical action at a time", async 
   await expect(assistant).toContainText("Prep for morning: Eat");
 
   await assistant.getByRole("button", { name: "Done" }).click();
-  await expect(assistant).toContainText("Brush teeth.");
+  await expect(assistant).toContainText("Dental Care.");
 
   await assistant.getByRole("button", { name: "Done" }).click();
   await expect(assistant).toContainText("Get in bed and turn lights out.");

--- a/sleepops/playwright.config.ts
+++ b/sleepops/playwright.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   timeout: 30_000,
   use: {
     baseURL: "http://127.0.0.1:3000",
+    timezoneId: "UTC",
     trace: "retain-on-failure",
   },
   webServer: {

--- a/sleepops/src/app/sleep-compiler.tsx
+++ b/sleepops/src/app/sleep-compiler.tsx
@@ -3,8 +3,15 @@
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import {
   REQUIRED_SLEEP_MINUTES,
+  buildShutdownActions,
+  buildShutdownWindow,
   buildSleepSchedule,
+  formatClockTime,
   formatDuration,
+  getShutdownProgress,
+  isShutdownWindowActive,
+  type ShutdownProgress,
+  type ShutdownWindow,
 } from "@/lib/sleep";
 import {
   addStep,
@@ -51,6 +58,9 @@ export function SleepCompiler() {
   const [useProfiledMorningRoutine, setUseProfiledMorningRoutine] =
     useState(false);
   const [commuteBufferMinutes, setCommuteBufferMinutes] = useState(30);
+  const [shutdownPreviewMode, setShutdownPreviewMode] = useState(false);
+  const [completedShutdownActions, setCompletedShutdownActions] = useState(0);
+  const currentTime = useCurrentClockTime();
 
   const { recordDateKey, retainedStartKey, setRecordDateKey, todayKey } =
     useProfilerDateKeys();
@@ -129,10 +139,64 @@ export function SleepCompiler() {
   );
 
   const hasWarning = schedule.constraintWarning !== null;
+  const shutdownWindow = useMemo(
+    () =>
+      buildShutdownWindow({
+        lightsOutTime: schedule.latestBedtime,
+        shutdownMinutes: schedule.shutdownMinutes,
+      }),
+    [schedule.latestBedtime, schedule.shutdownMinutes],
+  );
+  const shutdownActions = useMemo(
+    () =>
+      buildShutdownActions({
+        eveningTasks: routineCompression.eveningTasks,
+        eveningPreparationTasks: routineCompression.eveningPreparationTasks,
+      }),
+    [
+      routineCompression.eveningTasks,
+      routineCompression.eveningPreparationTasks,
+    ],
+  );
+  const shutdownProgress = useMemo(
+    () => getShutdownProgress(shutdownActions, completedShutdownActions),
+    [shutdownActions, completedShutdownActions],
+  );
+  const isShutdownActive =
+    currentTime !== null && isShutdownWindowActive(shutdownWindow, currentTime);
+  const showShutdownAssistant =
+    shutdownPreviewMode || (!hasWarning && isShutdownActive);
+
   const applyCompressedRoutine = () => {
     setManualMorningRoutineMinutes(routineCompression.minimumMorningMinutes);
     setUseProfiledMorningRoutine(false);
   };
+
+  const enterShutdownPreview = () => {
+    setCompletedShutdownActions(0);
+    setShutdownPreviewMode(true);
+  };
+
+  const exitShutdownPreview = () => {
+    setShutdownPreviewMode(false);
+    setCompletedShutdownActions(0);
+  };
+
+  if (showShutdownAssistant) {
+    return (
+      <ShutdownAssistant
+        isPreview={shutdownPreviewMode}
+        onAdvance={() =>
+          setCompletedShutdownActions((current) =>
+            Math.min(current + 1, shutdownActions.length),
+          )
+        }
+        onExitPreview={exitShutdownPreview}
+        progress={shutdownProgress}
+        window={shutdownWindow}
+      />
+    );
+  }
 
   const results = [
     { label: "Wake time", value: schedule.wakeTime },
@@ -204,6 +268,14 @@ export function SleepCompiler() {
                   : `Start shutdown by ${schedule.shutdownStartTime}`}
               </p>
             </div>
+
+            <button
+              className="h-12 w-full border border-[#166534] bg-[#166534] px-4 text-sm font-semibold text-white hover:bg-[#14532d] sm:w-auto"
+              onClick={enterShutdownPreview}
+              type="button"
+            >
+              Preview shutdown mode
+            </button>
           </div>
 
           <div className="grid gap-3 text-sm text-[#52525b]">
@@ -580,6 +652,67 @@ type DurationControlProps = {
   disabled?: boolean;
 };
 
+function ShutdownAssistant({
+  isPreview,
+  onAdvance,
+  onExitPreview,
+  progress,
+  window: shutdownWindow,
+}: {
+  isPreview: boolean;
+  onAdvance: () => void;
+  onExitPreview: () => void;
+  progress: ShutdownProgress;
+  window: ShutdownWindow;
+}) {
+  const isComplete = progress.status === "complete";
+  const actionNumber = progress.completedActions + 1;
+
+  return (
+    <main className="min-h-screen bg-[#101513] px-4 py-5 text-white sm:px-6 lg:px-8">
+      <section
+        aria-label="Evening shutdown assistant"
+        className="mx-auto flex min-h-[calc(100vh-2.5rem)] w-full max-w-3xl flex-col justify-center gap-8 border border-[#34443c] bg-[#16211c] p-5 shadow-sm sm:p-8"
+      >
+        <div className="space-y-3">
+          <p className="text-sm font-semibold text-[#86efac]">
+            Shutdown {shutdownWindow.shutdownStartTime}-{shutdownWindow.lightsOutTime}
+          </p>
+          <h1 className="text-4xl font-semibold leading-tight sm:text-6xl">
+            {isComplete ? "Lights out" : progress.action.label}
+          </h1>
+          <p className="text-sm text-[#d1d5db]">
+            {isComplete
+              ? "Shutdown complete. Go to bed now."
+              : `Action ${actionNumber} of ${progress.totalActions}`}
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row">
+          {progress.status === "active" ? (
+            <button
+              className="h-14 border border-[#bbf7d0] bg-[#bbf7d0] px-5 text-base font-semibold text-[#101513] hover:bg-[#86efac]"
+              onClick={onAdvance}
+              type="button"
+            >
+              Done
+            </button>
+          ) : null}
+          {isPreview ? (
+            <button
+              className="h-14 border border-[#4b5f55] bg-transparent px-5 text-base font-semibold text-white hover:bg-[#1f2d27]"
+              onClick={onExitPreview}
+              type="button"
+            >
+              Back to planning
+            </button>
+          ) : null}
+        </div>
+      </section>
+    </main>
+  );
+}
+
 function CompressionBlock({
   emptyText,
   listLabel,
@@ -749,6 +882,24 @@ function makeStepId(): string {
   }
 
   return `step_${Math.random().toString(16).slice(2)}${Date.now().toString(16)}`;
+}
+
+function useCurrentClockTime(): string | null {
+  const [currentTime, setCurrentTime] = useState<string | null>(null);
+
+  useEffect(() => {
+    const updateCurrentTime = () => {
+      const now = new Date();
+      setCurrentTime(formatClockTime(now.getHours() * 60 + now.getMinutes()));
+    };
+
+    updateCurrentTime();
+    const intervalId = setInterval(updateCurrentTime, 30_000);
+
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return currentTime;
 }
 
 function useProfilerDateKeys() {

--- a/sleepops/src/app/sleep-compiler.tsx
+++ b/sleepops/src/app/sleep-compiler.tsx
@@ -59,7 +59,11 @@ export function SleepCompiler() {
     useState(false);
   const [commuteBufferMinutes, setCommuteBufferMinutes] = useState(30);
   const [shutdownPreviewMode, setShutdownPreviewMode] = useState(false);
-  const [completedShutdownActions, setCompletedShutdownActions] = useState(0);
+  const [shutdownProgressState, setShutdownProgressState] =
+    useState<ShutdownProgressState>({
+      sessionKey: "",
+      completedActions: 0,
+    });
   const currentTime = useCurrentClockTime();
 
   const { recordDateKey, retainedStartKey, setRecordDateKey, todayKey } =
@@ -158,6 +162,21 @@ export function SleepCompiler() {
       routineCompression.eveningPreparationTasks,
     ],
   );
+  const shutdownActionKey = shutdownActions
+    .map((action) => action.id)
+    .join("|");
+  const shutdownSessionKey = [
+    shutdownWindow.shutdownStartTime,
+    shutdownWindow.lightsOutTime,
+    shutdownActionKey,
+  ].join("|");
+  const shutdownProgressKey = `${
+    shutdownPreviewMode ? "preview" : "active"
+  }:${shutdownSessionKey}`;
+  const completedShutdownActions =
+    shutdownProgressState.sessionKey === shutdownProgressKey
+      ? shutdownProgressState.completedActions
+      : 0;
   const shutdownProgress = useMemo(
     () => getShutdownProgress(shutdownActions, completedShutdownActions),
     [shutdownActions, completedShutdownActions],
@@ -173,13 +192,16 @@ export function SleepCompiler() {
   };
 
   const enterShutdownPreview = () => {
-    setCompletedShutdownActions(0);
+    setShutdownProgressState({
+      sessionKey: `preview:${shutdownSessionKey}`,
+      completedActions: 0,
+    });
     setShutdownPreviewMode(true);
   };
 
   const exitShutdownPreview = () => {
     setShutdownPreviewMode(false);
-    setCompletedShutdownActions(0);
+    setShutdownProgressState({ sessionKey: "", completedActions: 0 });
   };
 
   if (showShutdownAssistant) {
@@ -187,9 +209,20 @@ export function SleepCompiler() {
       <ShutdownAssistant
         isPreview={shutdownPreviewMode}
         onAdvance={() =>
-          setCompletedShutdownActions((current) =>
-            Math.min(current + 1, shutdownActions.length),
-          )
+          setShutdownProgressState((current) => {
+            const currentCompletedActions =
+              current.sessionKey === shutdownProgressKey
+                ? current.completedActions
+                : 0;
+
+            return {
+              sessionKey: shutdownProgressKey,
+              completedActions: Math.min(
+                currentCompletedActions + 1,
+                shutdownActions.length,
+              ),
+            };
+          })
         }
         onExitPreview={exitShutdownPreview}
         progress={shutdownProgress}
@@ -650,6 +683,11 @@ type DurationControlProps = {
   value: number;
   onChange: (value: number) => void;
   disabled?: boolean;
+};
+
+type ShutdownProgressState = {
+  sessionKey: string;
+  completedActions: number;
 };
 
 function ShutdownAssistant({

--- a/sleepops/src/app/sleep-compiler.tsx
+++ b/sleepops/src/app/sleep-compiler.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import {
+  DEFAULT_SHUTDOWN_MINUTES,
+  MAX_SHUTDOWN_MINUTES,
   REQUIRED_SLEEP_MINUTES,
   buildShutdownActions,
   buildShutdownWindow,
@@ -10,6 +12,8 @@ import {
   formatDuration,
   getShutdownProgress,
   isShutdownWindowActive,
+  parseClockTime,
+  selectShutdownRoutineTasks,
   type ShutdownProgress,
   type ShutdownWindow,
 } from "@/lib/sleep";
@@ -64,7 +68,7 @@ export function SleepCompiler() {
       sessionKey: "",
       completedActions: 0,
     });
-  const currentTime = useCurrentClockTime();
+  const currentClock = useCurrentClock();
 
   const { recordDateKey, retainedStartKey, setRecordDateKey, todayKey } =
     useProfilerDateKeys();
@@ -131,6 +135,18 @@ export function SleepCompiler() {
     () => compressMorningRoutine(profiler, recordDayMinutesByStepId),
     [profiler, recordDayMinutesByStepId],
   );
+  const selectedShutdownTasks = useMemo(
+    () =>
+      selectShutdownRoutineTasks({
+        availableMinutes: MAX_SHUTDOWN_MINUTES - DEFAULT_SHUTDOWN_MINUTES,
+        eveningTasks: routineCompression.eveningTasks,
+        eveningPreparationTasks: routineCompression.eveningPreparationTasks,
+      }),
+    [
+      routineCompression.eveningTasks,
+      routineCompression.eveningPreparationTasks,
+    ],
+  );
 
   const schedule = useMemo(
     () =>
@@ -138,8 +154,15 @@ export function SleepCompiler() {
         workStart,
         morningRoutineMinutes: effectiveMorningRoutineMinutes,
         commuteBufferMinutes,
+        shutdownMinutes:
+          DEFAULT_SHUTDOWN_MINUTES + selectedShutdownTasks.totalMinutes,
       }),
-    [workStart, effectiveMorningRoutineMinutes, commuteBufferMinutes],
+    [
+      workStart,
+      effectiveMorningRoutineMinutes,
+      commuteBufferMinutes,
+      selectedShutdownTasks.totalMinutes,
+    ],
   );
 
   const hasWarning = schedule.constraintWarning !== null;
@@ -154,18 +177,21 @@ export function SleepCompiler() {
   const shutdownActions = useMemo(
     () =>
       buildShutdownActions({
-        eveningTasks: routineCompression.eveningTasks,
-        eveningPreparationTasks: routineCompression.eveningPreparationTasks,
+        eveningTasks: selectedShutdownTasks.eveningTasks,
+        eveningPreparationTasks: selectedShutdownTasks.eveningPreparationTasks,
       }),
     [
-      routineCompression.eveningTasks,
-      routineCompression.eveningPreparationTasks,
+      selectedShutdownTasks.eveningTasks,
+      selectedShutdownTasks.eveningPreparationTasks,
     ],
   );
   const shutdownActionKey = shutdownActions
     .map((action) => action.id)
     .join("|");
   const shutdownSessionKey = [
+    currentClock
+      ? shutdownWindowInstanceKey(shutdownWindow, currentClock)
+      : "pending",
     shutdownWindow.shutdownStartTime,
     shutdownWindow.lightsOutTime,
     shutdownActionKey,
@@ -181,7 +207,9 @@ export function SleepCompiler() {
     () => getShutdownProgress(shutdownActions, completedShutdownActions),
     [shutdownActions, completedShutdownActions],
   );
-  const isShutdownActive = isShutdownWindowActive(shutdownWindow, currentTime);
+  const isShutdownActive =
+    currentClock !== null &&
+    isShutdownWindowActive(shutdownWindow, currentClock.time);
   const showShutdownAssistant = shutdownPreviewMode || isShutdownActive;
 
   const applyCompressedRoutine = () => {
@@ -201,6 +229,10 @@ export function SleepCompiler() {
     setShutdownPreviewMode(false);
     setShutdownProgressState({ sessionKey: "", completedActions: 0 });
   };
+
+  if (currentClock === null) {
+    return <SleepOpsLoading />;
+  }
 
   if (showShutdownAssistant) {
     return (
@@ -688,6 +720,25 @@ type ShutdownProgressState = {
   completedActions: number;
 };
 
+type ClockSnapshot = {
+  dateKey: string;
+  previousDateKey: string;
+  time: string;
+};
+
+function SleepOpsLoading() {
+  return (
+    <main className="min-h-screen bg-[#f6f8f7] px-4 py-5 text-[#18181b] sm:px-6 lg:px-8">
+      <section
+        aria-label="SleepOps loading"
+        className="mx-auto flex min-h-[calc(100vh-2.5rem)] w-full max-w-3xl items-center border border-[#d8dfda] bg-white p-5 shadow-sm sm:p-8"
+      >
+        <p className="text-sm font-semibold text-[#166534]">SleepOps</p>
+      </section>
+    </main>
+  );
+}
+
 function ShutdownAssistant({
   isPreview,
   onAdvance,
@@ -920,23 +971,47 @@ function makeStepId(): string {
   return `step_${Math.random().toString(16).slice(2)}${Date.now().toString(16)}`;
 }
 
-function useCurrentClockTime(): string {
-  const [currentTime, setCurrentTime] = useState(readCurrentClockTime);
+function useCurrentClock(): ClockSnapshot | null {
+  const [currentClock, setCurrentClock] = useState<ClockSnapshot | null>(null);
 
   useEffect(() => {
+    const updateClock = () => setCurrentClock(readCurrentClock());
+    const initTimeoutId = setTimeout(updateClock, 0);
     const intervalId = setInterval(() => {
-      setCurrentTime(readCurrentClockTime());
+      setCurrentClock(readCurrentClock());
     }, 30_000);
 
-    return () => clearInterval(intervalId);
+    return () => {
+      clearTimeout(initTimeoutId);
+      clearInterval(intervalId);
+    };
   }, []);
 
-  return currentTime;
+  return currentClock;
 }
 
-function readCurrentClockTime(): string {
+function readCurrentClock(): ClockSnapshot {
   const now = new Date();
-  return formatClockTime(now.getHours() * 60 + now.getMinutes());
+  const dateKey = toDateKey(now);
+
+  return {
+    dateKey,
+    previousDateKey: addDaysToDateKey(dateKey, -1),
+    time: formatClockTime(now.getHours() * 60 + now.getMinutes()),
+  };
+}
+
+function shutdownWindowInstanceKey(
+  window: ShutdownWindow,
+  clock: ClockSnapshot,
+): string {
+  const startMinutes = parseClockTime(window.shutdownStartTime);
+  const lightsOutMinutes = parseClockTime(window.lightsOutTime);
+  const currentMinutes = parseClockTime(clock.time);
+  const startsOnPreviousDay =
+    startMinutes >= lightsOutMinutes && currentMinutes < lightsOutMinutes;
+
+  return startsOnPreviousDay ? clock.previousDateKey : clock.dateKey;
 }
 
 function useProfilerDateKeys() {

--- a/sleepops/src/app/sleep-compiler.tsx
+++ b/sleepops/src/app/sleep-compiler.tsx
@@ -181,8 +181,7 @@ export function SleepCompiler() {
     () => getShutdownProgress(shutdownActions, completedShutdownActions),
     [shutdownActions, completedShutdownActions],
   );
-  const isShutdownActive =
-    currentTime !== null && isShutdownWindowActive(shutdownWindow, currentTime);
+  const isShutdownActive = isShutdownWindowActive(shutdownWindow, currentTime);
   const showShutdownAssistant = shutdownPreviewMode || isShutdownActive;
 
   const applyCompressedRoutine = () => {
@@ -921,22 +920,23 @@ function makeStepId(): string {
   return `step_${Math.random().toString(16).slice(2)}${Date.now().toString(16)}`;
 }
 
-function useCurrentClockTime(): string | null {
-  const [currentTime, setCurrentTime] = useState<string | null>(null);
+function useCurrentClockTime(): string {
+  const [currentTime, setCurrentTime] = useState(readCurrentClockTime);
 
   useEffect(() => {
-    const updateCurrentTime = () => {
-      const now = new Date();
-      setCurrentTime(formatClockTime(now.getHours() * 60 + now.getMinutes()));
-    };
-
-    updateCurrentTime();
-    const intervalId = setInterval(updateCurrentTime, 30_000);
+    const intervalId = setInterval(() => {
+      setCurrentTime(readCurrentClockTime());
+    }, 30_000);
 
     return () => clearInterval(intervalId);
   }, []);
 
   return currentTime;
+}
+
+function readCurrentClockTime(): string {
+  const now = new Date();
+  return formatClockTime(now.getHours() * 60 + now.getMinutes());
 }
 
 function useProfilerDateKeys() {

--- a/sleepops/src/app/sleep-compiler.tsx
+++ b/sleepops/src/app/sleep-compiler.tsx
@@ -183,8 +183,7 @@ export function SleepCompiler() {
   );
   const isShutdownActive =
     currentTime !== null && isShutdownWindowActive(shutdownWindow, currentTime);
-  const showShutdownAssistant =
-    shutdownPreviewMode || (!hasWarning && isShutdownActive);
+  const showShutdownAssistant = shutdownPreviewMode || isShutdownActive;
 
   const applyCompressedRoutine = () => {
     setManualMorningRoutineMinutes(routineCompression.minimumMorningMinutes);

--- a/sleepops/src/lib/sleep/index.ts
+++ b/sleepops/src/lib/sleep/index.ts
@@ -1,6 +1,8 @@
 export {
   DAY_MINUTES,
   DEFAULT_SHUTDOWN_MINUTES,
+  MAX_SHUTDOWN_MINUTES,
+  MIN_SHUTDOWN_MINUTES,
   REQUIRED_SLEEP_MINUTES,
   buildSleepSchedule,
   formatClockTime,
@@ -10,8 +12,6 @@ export {
   type SleepScheduleInput,
 } from "./schedule";
 export {
-  MAX_SHUTDOWN_MINUTES,
-  MIN_SHUTDOWN_MINUTES,
   buildShutdownActions,
   buildShutdownWindow,
   getShutdownProgress,

--- a/sleepops/src/lib/sleep/index.ts
+++ b/sleepops/src/lib/sleep/index.ts
@@ -16,9 +16,11 @@ export {
   buildShutdownWindow,
   getShutdownProgress,
   isShutdownWindowActive,
+  selectShutdownRoutineTasks,
   type ShutdownAction,
   type ShutdownProgress,
   type ShutdownRoutineTask,
+  type ShutdownRoutineTaskSelection,
   type ShutdownWindow,
   type ShutdownWindowInput,
 } from "./shutdown";

--- a/sleepops/src/lib/sleep/index.ts
+++ b/sleepops/src/lib/sleep/index.ts
@@ -9,3 +9,16 @@ export {
   type SleepSchedule,
   type SleepScheduleInput,
 } from "./schedule";
+export {
+  MAX_SHUTDOWN_MINUTES,
+  MIN_SHUTDOWN_MINUTES,
+  buildShutdownActions,
+  buildShutdownWindow,
+  getShutdownProgress,
+  isShutdownWindowActive,
+  type ShutdownAction,
+  type ShutdownProgress,
+  type ShutdownRoutineTask,
+  type ShutdownWindow,
+  type ShutdownWindowInput,
+} from "./shutdown";

--- a/sleepops/src/lib/sleep/schedule.test.ts
+++ b/sleepops/src/lib/sleep/schedule.test.ts
@@ -66,4 +66,33 @@ describe("sleep scheduling", () => {
       }),
     ).toThrow(RangeError);
   });
+
+  it("owns shutdown duration validation for the 45-75 minute window", () => {
+    expect(() =>
+      buildSleepSchedule({
+        workStart: "09:00",
+        morningRoutineMinutes: 75,
+        commuteBufferMinutes: 30,
+        shutdownMinutes: 44,
+      }),
+    ).toThrow(RangeError);
+
+    expect(() =>
+      buildSleepSchedule({
+        workStart: "09:00",
+        morningRoutineMinutes: 75,
+        commuteBufferMinutes: 30,
+        shutdownMinutes: 76,
+      }),
+    ).toThrow(RangeError);
+
+    expect(
+      buildSleepSchedule({
+        workStart: "09:00",
+        morningRoutineMinutes: 75,
+        commuteBufferMinutes: 30,
+        shutdownMinutes: 75,
+      }).shutdownStartTime,
+    ).toBe("21:00");
+  });
 });

--- a/sleepops/src/lib/sleep/schedule.ts
+++ b/sleepops/src/lib/sleep/schedule.ts
@@ -1,5 +1,7 @@
 export const DAY_MINUTES = 24 * 60;
 export const REQUIRED_SLEEP_MINUTES = 9 * 60;
+export const MIN_SHUTDOWN_MINUTES = 45;
+export const MAX_SHUTDOWN_MINUTES = 75;
 export const DEFAULT_SHUTDOWN_MINUTES = 45;
 
 const CLOCK_TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/;
@@ -35,7 +37,7 @@ export function buildSleepSchedule(input: SleepScheduleInput): SleepSchedule {
   assertWholeMinutes(requiredSleepMinutes, "requiredSleepMinutes");
   assertWholeMinutes(input.morningRoutineMinutes, "morningRoutineMinutes");
   assertWholeMinutes(input.commuteBufferMinutes, "commuteBufferMinutes");
-  assertWholeMinutes(shutdownMinutes, "shutdownMinutes");
+  assertShutdownMinutes(shutdownMinutes);
 
   const morningBlockMinutes =
     input.morningRoutineMinutes + input.commuteBufferMinutes;
@@ -105,6 +107,19 @@ export function formatDuration(totalMinutes: number): string {
 function assertWholeMinutes(value: number, name: string): void {
   if (!Number.isFinite(value) || value < 0 || !Number.isInteger(value)) {
     throw new RangeError(`${name} must be a whole number of minutes.`);
+  }
+}
+
+function assertShutdownMinutes(shutdownMinutes: number): void {
+  assertWholeMinutes(shutdownMinutes, "shutdownMinutes");
+
+  if (
+    shutdownMinutes < MIN_SHUTDOWN_MINUTES ||
+    shutdownMinutes > MAX_SHUTDOWN_MINUTES
+  ) {
+    throw new RangeError(
+      `shutdownMinutes must be between ${MIN_SHUTDOWN_MINUTES} and ${MAX_SHUTDOWN_MINUTES}.`,
+    );
   }
 }
 

--- a/sleepops/src/lib/sleep/shutdown.test.ts
+++ b/sleepops/src/lib/sleep/shutdown.test.ts
@@ -27,22 +27,6 @@ describe("shutdown assistant", () => {
     ).toBe("22:00");
   });
 
-  it("rejects shutdown durations outside the MVP range", () => {
-    expect(() =>
-      buildShutdownWindow({
-        lightsOutTime: "22:15",
-        shutdownMinutes: 44,
-      }),
-    ).toThrow(RangeError);
-
-    expect(() =>
-      buildShutdownWindow({
-        lightsOutTime: "22:15",
-        shutdownMinutes: 76,
-      }),
-    ).toThrow(RangeError);
-  });
-
   it("detects active shutdown windows before lights-out", () => {
     const window = buildShutdownWindow({
       lightsOutTime: "22:15",

--- a/sleepops/src/lib/sleep/shutdown.test.ts
+++ b/sleepops/src/lib/sleep/shutdown.test.ts
@@ -4,6 +4,7 @@ import {
   buildShutdownWindow,
   getShutdownProgress,
   isShutdownWindowActive,
+  selectShutdownRoutineTasks,
 } from "./shutdown";
 
 describe("shutdown assistant", () => {
@@ -92,6 +93,24 @@ describe("shutdown assistant", () => {
       "Prep for morning: Brush Teeth",
       "Get in bed and turn lights out.",
     ]);
+  });
+
+  it("keeps known-duration routine tasks outside shutdown when they do not fit", () => {
+    const selection = selectShutdownRoutineTasks({
+      availableMinutes: 30,
+      eveningTasks: [{ stepId: "exercise", label: "Exercise", minutes: 60 }],
+      eveningPreparationTasks: [
+        { stepId: "bag", label: "Pack bag", minutes: 5 },
+      ],
+    });
+
+    expect(selection).toEqual({
+      eveningTasks: [],
+      eveningPreparationTasks: [
+        { stepId: "bag", label: "Pack bag", minutes: 5 },
+      ],
+      totalMinutes: 5,
+    });
   });
 
   it("tracks the current action and clear completion state", () => {

--- a/sleepops/src/lib/sleep/shutdown.test.ts
+++ b/sleepops/src/lib/sleep/shutdown.test.ts
@@ -86,7 +86,26 @@ describe("shutdown assistant", () => {
       "Do evening task: Mobility",
       "Prep for morning: Pack bag",
       "Prep for morning: Choose clothes",
-      "Brush teeth.",
+      "Dental Care.",
+      "Get in bed and turn lights out.",
+    ]);
+  });
+
+  it("does not add default dental care when an evening task already covers it", () => {
+    const actions = buildShutdownActions({
+      eveningPreparationTasks: [
+        { stepId: "brush-teeth", label: "Brush Teeth" },
+      ],
+    });
+
+    expect(
+      actions.filter((action) =>
+        /brush teeth|dental care/i.test(action.label),
+      ),
+    ).toHaveLength(1);
+    expect(actions.map((action) => action.label)).toEqual([
+      "Close laptop and put it away.",
+      "Prep for morning: Brush Teeth",
       "Get in bed and turn lights out.",
     ]);
   });
@@ -104,7 +123,7 @@ describe("shutdown assistant", () => {
     });
     expect(getShutdownProgress(actions, 2)).toMatchObject({
       status: "active",
-      action: { id: "brush-teeth" },
+      action: { id: "dental-care" },
       completedActions: 2,
       totalActions: 4,
     });

--- a/sleepops/src/lib/sleep/shutdown.test.ts
+++ b/sleepops/src/lib/sleep/shutdown.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildShutdownActions,
+  buildShutdownWindow,
+  getShutdownProgress,
+  isShutdownWindowActive,
+} from "./shutdown";
+
+describe("shutdown assistant", () => {
+  it("derives the shutdown window from lights-out and a valid duration", () => {
+    expect(
+      buildShutdownWindow({
+        lightsOutTime: "22:15",
+        shutdownMinutes: 45,
+      }),
+    ).toEqual({
+      lightsOutTime: "22:15",
+      shutdownStartTime: "21:30",
+      shutdownMinutes: 45,
+    });
+
+    expect(
+      buildShutdownWindow({
+        lightsOutTime: "23:15",
+        shutdownMinutes: 75,
+      }).shutdownStartTime,
+    ).toBe("22:00");
+  });
+
+  it("rejects shutdown durations outside the MVP range", () => {
+    expect(() =>
+      buildShutdownWindow({
+        lightsOutTime: "22:15",
+        shutdownMinutes: 44,
+      }),
+    ).toThrow(RangeError);
+
+    expect(() =>
+      buildShutdownWindow({
+        lightsOutTime: "22:15",
+        shutdownMinutes: 76,
+      }),
+    ).toThrow(RangeError);
+  });
+
+  it("detects active shutdown windows before lights-out", () => {
+    const window = buildShutdownWindow({
+      lightsOutTime: "22:15",
+      shutdownMinutes: 45,
+    });
+
+    expect(isShutdownWindowActive(window, "21:29")).toBe(false);
+    expect(isShutdownWindowActive(window, "21:30")).toBe(true);
+    expect(isShutdownWindowActive(window, "22:14")).toBe(true);
+    expect(isShutdownWindowActive(window, "22:15")).toBe(false);
+  });
+
+  it("detects active shutdown windows that cross midnight", () => {
+    const window = buildShutdownWindow({
+      lightsOutTime: "00:30",
+      shutdownMinutes: 45,
+    });
+
+    expect(window.shutdownStartTime).toBe("23:45");
+    expect(isShutdownWindowActive(window, "23:44")).toBe(false);
+    expect(isShutdownWindowActive(window, "23:50")).toBe(true);
+    expect(isShutdownWindowActive(window, "00:10")).toBe(true);
+    expect(isShutdownWindowActive(window, "00:30")).toBe(false);
+  });
+
+  it("orders fixed shutdown actions before evening and prep tasks, then bed", () => {
+    const actions = buildShutdownActions({
+      eveningTasks: [
+        { stepId: "shower", label: "Shower" },
+        { stepId: "exercise", label: "Mobility" },
+      ],
+      eveningPreparationTasks: [
+        { stepId: "bag", label: "Pack bag" },
+        { stepId: "clothes", label: "Choose clothes" },
+      ],
+    });
+
+    expect(actions.map((action) => action.label)).toEqual([
+      "Close laptop and put it away.",
+      "Do evening task: Shower",
+      "Do evening task: Mobility",
+      "Prep for morning: Pack bag",
+      "Prep for morning: Choose clothes",
+      "Brush teeth.",
+      "Get in bed and turn lights out.",
+    ]);
+  });
+
+  it("tracks the current action and clear completion state", () => {
+    const actions = buildShutdownActions({
+      eveningPreparationTasks: [{ stepId: "bag", label: "Pack bag" }],
+    });
+
+    expect(getShutdownProgress(actions, 0)).toMatchObject({
+      status: "active",
+      action: { id: "close-laptop" },
+      completedActions: 0,
+      totalActions: 4,
+    });
+    expect(getShutdownProgress(actions, 2)).toMatchObject({
+      status: "active",
+      action: { id: "brush-teeth" },
+      completedActions: 2,
+      totalActions: 4,
+    });
+    expect(getShutdownProgress(actions, actions.length)).toEqual({
+      status: "complete",
+      action: null,
+      completedActions: actions.length,
+      totalActions: actions.length,
+    });
+  });
+});

--- a/sleepops/src/lib/sleep/shutdown.ts
+++ b/sleepops/src/lib/sleep/shutdown.ts
@@ -1,0 +1,151 @@
+import { formatClockTime, parseClockTime } from "./schedule";
+
+export const MIN_SHUTDOWN_MINUTES = 45;
+export const MAX_SHUTDOWN_MINUTES = 75;
+
+export type ShutdownRoutineTask = {
+  stepId: string;
+  label: string;
+  minutes?: number;
+};
+
+export type ShutdownWindowInput = {
+  lightsOutTime: string;
+  shutdownMinutes: number;
+};
+
+export type ShutdownWindow = {
+  lightsOutTime: string;
+  shutdownStartTime: string;
+  shutdownMinutes: number;
+};
+
+export type ShutdownAction = {
+  id: string;
+  label: string;
+};
+
+export type ShutdownProgress =
+  | {
+      status: "active";
+      action: ShutdownAction;
+      completedActions: number;
+      totalActions: number;
+    }
+  | {
+      status: "complete";
+      action: null;
+      completedActions: number;
+      totalActions: number;
+    };
+
+export function buildShutdownWindow(
+  input: ShutdownWindowInput,
+): ShutdownWindow {
+  assertShutdownMinutes(input.shutdownMinutes);
+
+  const lightsOutMinutes = parseClockTime(input.lightsOutTime);
+
+  return {
+    lightsOutTime: input.lightsOutTime,
+    shutdownStartTime: formatClockTime(lightsOutMinutes - input.shutdownMinutes),
+    shutdownMinutes: input.shutdownMinutes,
+  };
+}
+
+export function isShutdownWindowActive(
+  window: ShutdownWindow,
+  currentTime: string,
+): boolean {
+  const startMinutes = parseClockTime(window.shutdownStartTime);
+  const endMinutes = parseClockTime(window.lightsOutTime);
+  const currentMinutes = parseClockTime(currentTime);
+
+  if (startMinutes < endMinutes) {
+    return currentMinutes >= startMinutes && currentMinutes < endMinutes;
+  }
+
+  return currentMinutes >= startMinutes || currentMinutes < endMinutes;
+}
+
+export function buildShutdownActions({
+  eveningTasks = [],
+  eveningPreparationTasks = [],
+}: {
+  eveningTasks?: ShutdownRoutineTask[];
+  eveningPreparationTasks?: ShutdownRoutineTask[];
+} = {}): ShutdownAction[] {
+  const taskActions = [
+    ...eveningTasks.map((task) => ({
+      id: `evening:${task.stepId}`,
+      label: `Do evening task: ${task.label}`,
+    })),
+    ...eveningPreparationTasks.map((task) => ({
+      id: `prep:${task.stepId}`,
+      label: `Prep for morning: ${task.label}`,
+    })),
+  ];
+
+  const hasBrushTeethAction = taskActions.some((action) =>
+    action.label.toLowerCase().includes("brush teeth"),
+  );
+
+  return [
+    {
+      id: "close-laptop",
+      label: "Close laptop and put it away.",
+    },
+    ...taskActions,
+    ...(hasBrushTeethAction
+      ? []
+      : [
+          {
+            id: "brush-teeth",
+            label: "Brush teeth.",
+          },
+        ]),
+    {
+      id: "lights-out",
+      label: "Get in bed and turn lights out.",
+    },
+  ];
+}
+
+export function getShutdownProgress(
+  actions: ShutdownAction[],
+  completedActions: number,
+): ShutdownProgress {
+  const totalActions = actions.length;
+  const safeCompletedActions = Math.min(
+    totalActions,
+    Math.max(0, Math.floor(completedActions)),
+  );
+
+  if (safeCompletedActions >= totalActions) {
+    return {
+      status: "complete",
+      action: null,
+      completedActions: safeCompletedActions,
+      totalActions,
+    };
+  }
+
+  return {
+    status: "active",
+    action: actions[safeCompletedActions],
+    completedActions: safeCompletedActions,
+    totalActions,
+  };
+}
+
+function assertShutdownMinutes(shutdownMinutes: number): void {
+  if (
+    !Number.isInteger(shutdownMinutes) ||
+    shutdownMinutes < MIN_SHUTDOWN_MINUTES ||
+    shutdownMinutes > MAX_SHUTDOWN_MINUTES
+  ) {
+    throw new RangeError(
+      `shutdownMinutes must be between ${MIN_SHUTDOWN_MINUTES} and ${MAX_SHUTDOWN_MINUTES}.`,
+    );
+  }
+}

--- a/sleepops/src/lib/sleep/shutdown.ts
+++ b/sleepops/src/lib/sleep/shutdown.ts
@@ -1,8 +1,5 @@
 import { formatClockTime, parseClockTime } from "./schedule";
 
-export const MIN_SHUTDOWN_MINUTES = 45;
-export const MAX_SHUTDOWN_MINUTES = 75;
-
 export type ShutdownRoutineTask = {
   stepId: string;
   label: string;
@@ -42,8 +39,6 @@ export type ShutdownProgress =
 export function buildShutdownWindow(
   input: ShutdownWindowInput,
 ): ShutdownWindow {
-  assertShutdownMinutes(input.shutdownMinutes);
-
   const lightsOutMinutes = parseClockTime(input.lightsOutTime);
 
   return {
@@ -136,18 +131,6 @@ export function getShutdownProgress(
     completedActions: safeCompletedActions,
     totalActions,
   };
-}
-
-function assertShutdownMinutes(shutdownMinutes: number): void {
-  if (
-    !Number.isInteger(shutdownMinutes) ||
-    shutdownMinutes < MIN_SHUTDOWN_MINUTES ||
-    shutdownMinutes > MAX_SHUTDOWN_MINUTES
-  ) {
-    throw new RangeError(
-      `shutdownMinutes must be between ${MIN_SHUTDOWN_MINUTES} and ${MAX_SHUTDOWN_MINUTES}.`,
-    );
-  }
 }
 
 function isDentalCareActionLabel(label: string): boolean {

--- a/sleepops/src/lib/sleep/shutdown.ts
+++ b/sleepops/src/lib/sleep/shutdown.ts
@@ -86,8 +86,8 @@ export function buildShutdownActions({
     })),
   ];
 
-  const hasBrushTeethAction = taskActions.some((action) =>
-    action.label.toLowerCase().includes("brush teeth"),
+  const hasDentalCareAction = taskActions.some((action) =>
+    isDentalCareActionLabel(action.label),
   );
 
   return [
@@ -96,12 +96,12 @@ export function buildShutdownActions({
       label: "Close laptop and put it away.",
     },
     ...taskActions,
-    ...(hasBrushTeethAction
+    ...(hasDentalCareAction
       ? []
       : [
           {
-            id: "brush-teeth",
-            label: "Brush teeth.",
+            id: "dental-care",
+            label: "Dental Care.",
           },
         ]),
     {
@@ -148,4 +148,12 @@ function assertShutdownMinutes(shutdownMinutes: number): void {
       `shutdownMinutes must be between ${MIN_SHUTDOWN_MINUTES} and ${MAX_SHUTDOWN_MINUTES}.`,
     );
   }
+}
+
+function isDentalCareActionLabel(label: string): boolean {
+  const normalizedLabel = label.toLowerCase();
+  return (
+    normalizedLabel.includes("brush teeth") ||
+    normalizedLabel.includes("dental care")
+  );
 }

--- a/sleepops/src/lib/sleep/shutdown.ts
+++ b/sleepops/src/lib/sleep/shutdown.ts
@@ -22,6 +22,12 @@ export type ShutdownAction = {
   label: string;
 };
 
+export type ShutdownRoutineTaskSelection = {
+  eveningTasks: ShutdownRoutineTask[];
+  eveningPreparationTasks: ShutdownRoutineTask[];
+  totalMinutes: number;
+};
+
 export type ShutdownProgress =
   | {
       status: "active";
@@ -104,6 +110,43 @@ export function buildShutdownActions({
       label: "Get in bed and turn lights out.",
     },
   ];
+}
+
+export function selectShutdownRoutineTasks({
+  availableMinutes,
+  eveningTasks = [],
+  eveningPreparationTasks = [],
+}: {
+  availableMinutes: number;
+  eveningTasks?: ShutdownRoutineTask[];
+  eveningPreparationTasks?: ShutdownRoutineTask[];
+}): ShutdownRoutineTaskSelection {
+  let remainingMinutes = Math.max(0, Math.floor(availableMinutes));
+  let totalMinutes = 0;
+
+  const selectTask = (task: ShutdownRoutineTask) => {
+    const minutes = task.minutes ?? 0;
+    if (minutes > remainingMinutes) {
+      return null;
+    }
+
+    remainingMinutes -= minutes;
+    totalMinutes += minutes;
+    return task;
+  };
+
+  const selectedEveningTasks = eveningTasks
+    .map(selectTask)
+    .filter((task): task is ShutdownRoutineTask => task !== null);
+  const selectedEveningPreparationTasks = eveningPreparationTasks
+    .map(selectTask)
+    .filter((task): task is ShutdownRoutineTask => task !== null);
+
+  return {
+    eveningTasks: selectedEveningTasks,
+    eveningPreparationTasks: selectedEveningPreparationTasks,
+    totalMinutes,
+  };
 }
 
 export function getShutdownProgress(


### PR DESCRIPTION
## Summary
- Add local shutdown-window and action-sequencing domain logic for the 45-75 minute lights-out window.
- Add active/preview shutdown mode that replaces planning controls with one physical action and a Done advance flow.
- Feed moved evening and prep tasks from the routine compressor into the shutdown sequence.

## Validation
- `npm run lint`
- `npm test`
- `npm run build`
- `npm --prefix sleepops run test:e2e`

Closes #15

<!-- START COPILOT ORIGINAL PROMPT -->

<details>

<summary>Original prompt</summary>

> Implement issue #15 in `mathemage/SleepOps`: add the Milestone 1 evening shutdown assistant.
>
> Context:
> - Read `README.md`, root `AGENTS.md`, `sleepops/AGENTS.md`, and the current SleepOps app before editing.
> - This should be implemented after #14 is merged. Reuse the sleep contract, profiled/compressed morning duration, and any evening task list produced by earlier issues.
> - The current sleep logic computes `latestBedtime` and `shutdownStartTime` in `sleepops/src/lib/sleep/schedule.ts`.
> - The current UI displays planning controls at all times; this issue adds an active shutdown mode that shows only one next physical action.
> - Because `sleepops/AGENTS.md` says this Next.js version may differ from older APIs, read the relevant docs under `sleepops/node_modules/next/dist/docs/` before changing Next.js code.
>
> Goal:
> Add a minimal active shutdown assistant that starts 45-75 minutes before lights-out and advances through one physical action at a time.
>
> Requirements:
> 1. Keep the implementation local-only. Do not add auth, Supabase, Prisma, remote sync, or push notifications; notifications belong to #16.
> 2. Add small domain logic for shutdown windows and action sequencing. The window must be derived from lights-out and a shutdown duration in the 45-75 minute range.
> 3. Provide a short deterministic action sequence suitable for the MVP, using any evening preparation tasks from #14 where available.
> 4. During active shutdown mode, hide or strongly de-emphasize planning/detail controls and show only the current physical action plus a way to advance to the next action.
> 5. The flow should end clearly at bed/lights-out.
> 6. Keep manual testing practical: include a way to enter or preview shutdown mode without waiting for the real clock.
> 7. Preserve the sleep contract, profiler, and compressor behavior already covered by tests.
>
> Validation:
> - Add Vitest coverage for shutdown window calculation, active/inactive detection, action ordering, and completion.
> - Add Playwright coverage for entering shutdown mode, seeing one action, advancing actions, and confirming planning controls are not the main surface during shutdown mode.
> - Run `npm run lint`, `npm test`, `npm run build`, and `npm --prefix sleepops run test:e2e`.
>
> Git/GitHub:
> - Create a branch from latest `main` after #14 is merged.
> - Use a commit message matching the repo convention, for example `feat(shutdown): Add evening shutdown assistant #15`.
> - Open a pull request that closes #15.
> - Keep the README minimal unless a command or behavior must be documented.

</details>